### PR TITLE
fix: updated default value of 'threshold' to '0.9'

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ It's important to note that if a miner's proof of storage is not valid, it indic
 # 5. Default Configuration
 - **CHUNK_SIZE**: Default value is `1<<22`. This represents the size of a chunk in bytes. The data is partitioned into chunks of this size (4MB) for storage and retrieval.
 - **DEFAULT_N_CHUNKS**: Default value is `1<<8`. This represents the minimum number of chunks a miner should provide at least. (1GB)
-- **THRESHOLD**: Default value is `0.01`. This represents the maximum amount of space the miner can use based on available space. It's used to determine the size of the partition for data storage.
+- **THRESHOLD**: Default value is `0.9`. This represents the maximum amount of space the miner can use based on available space. It's used to determine the size of the partition for data storage.
 - **db_root_path**: Default value is `'~/bittensor-db'`. This is the path where the SQLite databases for data storage and retrieval are stored.
 - **netuid**: Default value is `7`. This is the netuid of the storage subnet that the miner and validator are serving on.
 - **wallet.name**: Default value is `'default'`. This is the name of the wallet used by the miner and validator.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -56,7 +56,7 @@ pm2 start neurons/miner.py --name miner --interpreter python3 --
     --wallet.hotkey <OPTIONAL: your validator hotkey, defautl = default> # Must be created using the bittensor-cli btcli wallet new_hotkey
     --db_root_path <OPTIONAL: path where you want the DB files stored, default = "~/bittensor-db">  # This is where the partition will be created storing network data.
     --logging.debug # Run in debug mode, alternatively --logging.trace for trace mode
-    --threshold <OPTIONAL: threshold i.e. 0.01, default =  0.01>  # The threshold for the partitioning algorithm which is the maximum amount of space the miner can use based on available.
+    --threshold <OPTIONAL: threshold i.e. 0.9, default =  0.9>  # The threshold for the partitioning algorithm which is the maximum amount of space the miner can use based on available.
     --netuid <OPTIONAL: the subnet netuid, defualt = 7> # This is the netuid of the storage subnet.
     --subtensor.network local # <OPTIONAL: the bittensor chain endpoint, default = finney, local, test> : The chain endpoint to use to generate the partition.  (highly recommend running subtensor locally)
     --steps_per_reallocate <OPTIONAL: the number of steps before reallocating, default = 1000> # The number of steps before reallocating.

--- a/neurons/allocate.py
+++ b/neurons/allocate.py
@@ -30,7 +30,7 @@ def get_config() -> bt.config:
     parser.add_argument(
         "--threshold",
         type=float,
-        default=0.01,
+        default=0.9,
         required=False,
         help="Size of path to fill",
     )
@@ -285,7 +285,7 @@ def allocate(
     db_root_path: str,  # Path to the data database.
     wallet: bt.wallet,  # Wallet object
     metagraph: bt.metagraph,  # Metagraph object
-    threshold: float = 0.01,  # Threshold for the allocation.
+    threshold: float = 0.9,  # Threshold for the allocation.
     hash: bool = False,  # If True, the allocation is for a hash database. If False, the allocation is for a data database. Default is False.
 ) -> typing.List[dict]:
     """
@@ -295,7 +295,7 @@ def allocate(
         - db_path (str): The path to the data database.
         - wallet (bt.wallet): The wallet object containing the name and hotkey.
         - metagraph (bt.metagraph): The metagraph object containing the hotkeys.
-        - threshold (float): The threshold for the allocation. Default is 0.01.
+        - threshold (float): The threshold for the allocation. Default is 0.9.
 
     Returns:
         - list: A list of dictionaries. Each dictionary contains the allocation details for a hotkey.

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -64,7 +64,7 @@ def get_config():
     parser.add_argument(
         "--threshold",
         type=float,
-        default=0.001,
+        default=0.9,
         required=False,
         help="Size of path to fill",
     )


### PR DESCRIPTION
@salahawk i found, `threshold` value still defaults to `0.01`, which is not the value miners use for mining actually.
i changed it to 0.9 assuming miners often choose a value which is higher than 0.9 or so.